### PR TITLE
Merge classpath and classPath help files

### DIFF
--- a/src/main/resources/hudson/plugins/groovy/Groovy/config.jelly
+++ b/src/main/resources/hudson/plugins/groovy/Groovy/config.jelly
@@ -24,7 +24,7 @@
       <f:entry title="Groovy parameters" help="/plugin/groovy/parameters.html" >
         <f:expandableTextbox name="groovy.parameters" type="text" value="${instance.parameters}" />
       </f:entry>
-      <f:entry title="Class path" help="/plugin/groovy/classPath.html" >
+      <f:entry title="Class path" help="/plugin/groovy/classpath.html" >
         <f:expandableTextbox name="groovy.classPath" value="${instance.classPath}" />
       </f:entry>
       <f:entry title="Script parameters" help="/plugin/groovy/script-parameters.html" >

--- a/src/main/webapp/classPath.html
+++ b/src/main/webapp/classPath.html
@@ -1,3 +1,0 @@
-<p>
-Allows to set up more item in class path. Each line is one class path item. 
-</p>

--- a/src/main/webapp/classpath.html
+++ b/src/main/webapp/classpath.html
@@ -1,3 +1,3 @@
 <p>
-   Specify script classpath here.
+   Specify script classpath here. Each line is one class path item.
 </p>


### PR DESCRIPTION
Those tow files are redundent and introduce a tricky issue for contributors
that use a case-insensitive filesystem (OSX)
