### PR TITLE
Fix JENKINS-12080 : let non-admin user save job but not update system groovy script

### DIFF
--- a/src/main/resources/hudson/plugins/groovy/SystemGroovy/config.jelly
+++ b/src/main/resources/hudson/plugins/groovy/SystemGroovy/config.jelly
@@ -4,7 +4,19 @@
     <!-- <f:entry title="Groovy command">
         <f:textarea name="groovy.command" value="${instance.command}"/>       
     </f:entry> -->
-    
+
+    <j:if test="${not h.hasPermission(app.ADMINISTER)}">
+        <f:invisibleEntry>
+            <f:textbox name="groovy.secret" value="${instance.secret}" />
+        </f:invisibleEntry>
+        <f:entry >
+            <div class="warning">
+                Only Administrator can configure the System Groovy script to be executed.<br/>
+                Configuration is displayed for your information only, any change will be ignored.
+            </div>
+        </f:entry>
+    </j:if>
+
     <j:set var="instanceID" value="${descriptor.nextInstanceID()}" />
     <j:forEach var="d" items="${descriptor.scriptSources}" varStatus="loop">
       <f:radioBlock name="${instanceID}.scriptSource" help="${d.helpFile}" value="${loop.index}"
@@ -22,5 +34,7 @@
           <f:textbox name="groovy.classpath" value="${instance.classpath}" />
       </f:entry>
     </f:advanced>
+
+
     
 </j:jelly>

--- a/src/main/webapp/systemscript-projectconfig.html
+++ b/src/main/webapp/systemscript-projectconfig.html
@@ -2,4 +2,7 @@
   <p>
       Executes a system groovy script similarly to <i>hudson_url</i>/script. The script is <b>always</b> executed on master.
   </p>
+  <p>
+      You need to be Administrator to set the groovy script to be executed. In other case, changes will be ignored.
+  </p>
 </div>


### PR DESCRIPTION
as suggested by KK on JENKINS-12080, use a hidden text field to store the script configuration when user isn't admin, and restore it on job save. Jenkins core Secret is used to encrypt the system groovy configuration
