### PR TITLE
Provide build context

### DIFF
--- a/src/main/java/hudson/plugins/groovy/AbstractGroovy.java
+++ b/src/main/java/hudson/plugins/groovy/AbstractGroovy.java
@@ -24,7 +24,7 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public abstract class AbstractGroovy extends Builder {
 
-    public ScriptSource scriptSource;
+    protected ScriptSource scriptSource;
 
     public AbstractGroovy(ScriptSource scriptSource) {
         this.scriptSource = scriptSource;
@@ -37,19 +37,27 @@ public abstract class AbstractGroovy extends Builder {
         }
 
         /**
-         * Exctrats ScriptSource from given form data
+         * Extracts ScriptSource from given form data.
          */
-        protected ScriptSource getScriptSource(StaplerRequest req, JSONObject data) throws FormException {
+        protected ScriptSource getScriptSource(
+            final StaplerRequest req,
+            final JSONObject data
+        ) throws FormException {
             Object scriptSourceObject = data.get("scriptSource");
+
             if (scriptSourceObject instanceof JSONArray) {
-                //Dunno why this happens. Let's fix the JSON object so that newInstanceFromRadioList() doesn't go mad.
+                // Dunno why this happens. Let's fix the JSON object so that
+                // newInstanceFromRadioList() doesn't go mad.
+
                 JSONArray scriptSourceJSONArray = (JSONArray) scriptSourceObject;
                 JSONObject scriptSourceJSONObject = new JSONObject();
                 Object nestedObject = scriptSourceJSONArray.get(1);
+
                 if (nestedObject instanceof JSONObject) {
-                    //command/file path
+                    // command/file path
                     scriptSourceJSONObject.putAll((JSONObject) nestedObject);
-                    //selected radio button index
+
+                    // selected radio button index
                     scriptSourceJSONObject.put("value", scriptSourceJSONArray.get(0));
 
                     data.put("scriptSource", scriptSourceJSONObject);
@@ -59,12 +67,12 @@ public abstract class AbstractGroovy extends Builder {
             return ScriptSource.SOURCES.newInstanceFromRadioList(data, "scriptSource");
         }
 
-        //shortcut
+        // shortcut
         public static DescriptorList<ScriptSource> getScriptSources() {
             return ScriptSource.SOURCES;
         }
 
-        //Used for grouping radio buttons together
+        // Used for grouping radio buttons together
         private AtomicInteger instanceCounter = new AtomicInteger(0);
 
         public int nextInstanceID() {
@@ -80,8 +88,11 @@ public abstract class AbstractGroovy extends Builder {
      * @return Parsed properties. Never null.
      * @throws java.io.IOException
      */
-    public static Properties parseProperties(String properties) throws IOException {
+    public static Properties parseProperties(final String properties)
+        throws IOException
+    {
         Properties props = new Properties();
+
         if (properties != null) {
             try {
                 props.load(new StringReader(properties));
@@ -89,6 +100,7 @@ public abstract class AbstractGroovy extends Builder {
                 props.load(new ByteArrayInputStream(properties.getBytes()));
             }
         }
+
         return props;
     }
 }

--- a/src/main/java/hudson/plugins/groovy/GroovyTokenMacro.java
+++ b/src/main/java/hudson/plugins/groovy/GroovyTokenMacro.java
@@ -53,16 +53,24 @@ public class GroovyTokenMacro extends DataBoundTokenMacro {
 	}
 
 	@Override
-	public String evaluate(AbstractBuild<?, ?> context, TaskListener listener,String macroName) throws MacroEvaluationException, IOException,InterruptedException {
-		Groovy.DescriptorImpl decs = (Groovy.DescriptorImpl) Hudson.getInstance().getDescriptorOrDie(Groovy.class);
+	public String evaluate(
+		final AbstractBuild<?, ?> context,
+		final TaskListener listener,
+		final String macroName
+	) throws MacroEvaluationException, IOException, InterruptedException {
+		Groovy.DescriptorImpl decs =
+			(Groovy.DescriptorImpl) Hudson.getInstance().getDescriptorOrDie(Groovy.class);
+
 		if (decs.getAllowMacro()) {
 			StringScriptSource scriptSource = new StringScriptSource(script);
+
 			SystemGroovy systemGroovy = new SystemGroovy(scriptSource, "", null);
 			systemGroovy.perform(context, null, (BuildListener) listener);
+
 			Object output = systemGroovy.getOutput();
+			
 			return output != null ? output.toString() : "";
-		}
-		else{
+		} else {
 			return script;
 		}
 	}

--- a/src/main/java/hudson/plugins/groovy/SystemGroovy.java
+++ b/src/main/java/hudson/plugins/groovy/SystemGroovy.java
@@ -3,6 +3,7 @@ package hudson.plugins.groovy;
 import com.thoughtworks.xstream.XStream;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
+
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.*;
@@ -27,20 +28,20 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public class SystemGroovy extends AbstractGroovy {
 
-    //initial variable bindings
-    String bindings;
-    String classpath;
-    transient Object output;
+    // initial variable bindings
+    private String bindings;
+    private String classpath;
+    private transient Object output;
 
+    private static final XStream XSTREAM = new XStream2();
+    
     @DataBoundConstructor
-    public SystemGroovy(ScriptSource scriptSource, String bindings,String classpath) {
+    public SystemGroovy(final ScriptSource scriptSource, final String bindings, final String classpath) {
         super(scriptSource);
         this.bindings = bindings;
         this.classpath = classpath;
     }
 
-    private static final XStream XSTREAM = new XStream2();
-    
     /**
      * @return SystemGroovy as an encrypted String
      */
@@ -125,10 +126,10 @@ public class SystemGroovy extends AbstractGroovy {
         	return false;
         }
         
-         @Override
+        @Override
         public SystemGroovy newInstance(StaplerRequest req, JSONObject data) throws FormException {
 
-             //don't allow unauthorized users to modify scripts
+            // don't allow unauthorized users to modify scripts
             Authentication a = Hudson.getAuthentication();
             if (Hudson.getInstance().getACL().hasPermission(a,Hudson.ADMINISTER)) {
                 ScriptSource source = getScriptSource(req, data);


### PR DESCRIPTION
This patch makes the arguments passed to perform() available to the Groovy context.  This allows the script to behave exactly like any other `AbstractBuild`.  Specifically, I use it to determine the upstream causes of the build, and retrieve the `EnvVars` for some builds.
