### PR TITLE
use RUN_SCRIPTS permission

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.409</version>
+    <version>1.466</version>
   </parent>
   
   <artifactId>groovy</artifactId>

--- a/src/main/java/hudson/plugins/groovy/SystemGroovy.java
+++ b/src/main/java/hudson/plugins/groovy/SystemGroovy.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 
 import hudson.util.Secret;
 import hudson.util.XStream2;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.acegisecurity.Authentication;
@@ -120,7 +121,7 @@ public class SystemGroovy extends AbstractGroovy {
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType){
         	Authentication a = Hudson.getAuthentication();
-            if(Hudson.getInstance().getACL().hasPermission(a,Hudson.ADMINISTER)){
+            if(Hudson.getInstance().getACL().hasPermission(a, Jenkins.RUN_SCRIPTS)){
             	return true;
             }
         	return false;
@@ -131,7 +132,7 @@ public class SystemGroovy extends AbstractGroovy {
 
             // don't allow unauthorized users to modify scripts
             Authentication a = Hudson.getAuthentication();
-            if (Hudson.getInstance().getACL().hasPermission(a,Hudson.ADMINISTER)) {
+            if (Hudson.getInstance().getACL().hasPermission(a,Hudson.RUN_SCRIPTS)) {
                 ScriptSource source = getScriptSource(req, data);
                 String binds = data.getString("bindings");
                 String classp = data.getString("classpath");


### PR DESCRIPTION
RUN_SCRIPTS has been introduced as permission to execute arbitrary code on jenkins master. ADMINISTER by default include this permission, but in few specialized context (hosted jenkins) this may not be allowed.
