### PR TITLE
Prepare Update to Groovy 2.x

### DIFF
--- a/src/main/java/hudson/plugins/groovy/SystemGroovy.java
+++ b/src/main/java/hudson/plugins/groovy/SystemGroovy.java
@@ -11,6 +11,7 @@ import hudson.security.ACL;
 import hudson.tasks.Builder;
 
 import java.io.IOException;
+import java.io.InputStreamReader;
 
 import hudson.util.Secret;
 import hudson.util.XStream2;
@@ -79,7 +80,7 @@ public class SystemGroovy extends AbstractGroovy {
         shell.setVariable("out", listener.getLogger());
 
         output = shell.evaluate(
-            getScriptSource().getScriptStream(build.getWorkspace(),build,listener)
+            new InputStreamReader(getScriptSource().getScriptStream(build.getWorkspace(), build, listener))
         );
         
         if (output instanceof Boolean) {


### PR DESCRIPTION
I removed any usages of deprecated Groovy API to prepare an update to Groovy 2.x in Jenkins core.

See https://github.com/jenkinsci/jenkins/pull/1085 for details.
