### PR TITLE
Allow whitespaces in "properties" Jenkins field

### DIFF
--- a/src/main/java/hudson/plugins/groovy/Groovy.java
+++ b/src/main/java/hudson/plugins/groovy/Groovy.java
@@ -97,7 +97,7 @@ public class Groovy extends AbstractGroovy {
                     Properties props = parseProperties(properties);
                     
                     for (Entry<Object,Object> entry : props.entrySet()) {
-                        cmd.add(1, "-D" + entry.getKey() + "=" + entry.getValue() + "");
+                        cmd.add(1, "-D" + entry.getKey() + "=" + entry.getValue());
                     }
 
                     //Add javaOpts at the end


### PR DESCRIPTION
It was not possible to put white-spaces in the properties field. The JAVA_OPTS variable does not allow any spaces. To allow properties containing spaces, I used the 'cmd' list/array to introduce real -D parameters. Can we encounter some issues with backward compatibility using this method ?
