### PR TITLE
[JENKINS-28502] fixed installer display name

### DIFF
--- a/src/main/java/hudson/plugins/groovy/GroovyInstaller.java
+++ b/src/main/java/hudson/plugins/groovy/GroovyInstaller.java
@@ -15,7 +15,7 @@ public class GroovyInstaller extends DownloadFromUrlInstaller {
     @Extension                                                                                                                                 
     public static final class DescriptorImpl extends DownloadFromUrlInstaller.DescriptorImpl<GroovyInstaller> {                                
         public String getDisplayName() {                                                                                                       
-            return "Install from http://groovy.codehaus.org";                                                                                                  
+            return "Install from https://dl.bintray.com/groovy/maven/";
         }                                                                                                                                      
                                                                                                                                                
         @Override                                                                                                                              


### PR DESCRIPTION
Groovy distributions are hosted on Bintray after Codehaus was shut down.