### PR TITLE
Remove superfluous elements from plugin name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <artifactId>groovy</artifactId>
     <packaging>hpi</packaging>
-    <name>Hudson Groovy builder</name>
+    <name>Groovy</name>
     <version>1.26-SNAPSHOT</version>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Groovy+plugin</url>
 


### PR DESCRIPTION
* *Hudson* should be obvious; it's obsolete, and *Jenkins* would get removed from Jenkins anyway in the plugin manager.
* Removed *builder* as the plugin is just known as *Groovy Plugin* (e.g. wiki page) anyway