### PR TITLE
Add an ability to use system groovy script execution in internal logic of other plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,69 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                    <compilerId>groovy-eclipse-compiler</compilerId>
+                    <verbose>true</verbose>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-compiler</artifactId>
+                        <version>2.9.2-01</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-batch</artifactId>
+                        <version>2.3.7-01</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jvnet.hudson</groupId>
+                        <artifactId>xstream</artifactId>
+                        <version>1.4.7-jenkins-1</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>xmlpull</groupId>
+                                <artifactId>xmlpull</artifactId>
+                            </exclusion>
+                            <exclusion>
+                                <groupId>xpp3</groupId>
+                                <artifactId>xpp3_min</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-eclipse-compiler</artifactId>
+                <version>2.9.2-01</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <configuration>
+                    <additionalProjectnatures>
+                        <projectnature>org.eclipse.jdt.groovy.core.groovyNature</projectnature>
+                    </additionalProjectnatures>
+                    <sourceIncludes>
+                        <sourceInclude>**/*.groovy</sourceInclude>
+                    </sourceIncludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                     <encoding>UTF-8</encoding>
                     <compilerId>groovy-eclipse-compiler</compilerId>
                     <verbose>true</verbose>

--- a/src/main/groovy/hudson/plugins/groovy/AbstractScript.groovy
+++ b/src/main/groovy/hudson/plugins/groovy/AbstractScript.groovy
@@ -1,0 +1,32 @@
+package hudson.plugins.groovy
+
+import hudson.EnvVars
+import hudson.model.Computer
+import hudson.remoting.VirtualChannel
+
+abstract class AbstractScript extends Script {
+
+    def runScriptOnChannel(VirtualChannel channel, String script) {
+        SlaveTask task = new SlaveTask(script)
+        EnvVars envVars = build.getEnvironment(listener)
+        envVars.overrideAll(build.getBuildVariables())
+        task.putPropMap(envVars)
+        channel.call(task)
+    }
+
+    def runScriptOnCurrentNode(String script) {
+        Computer computer = build.getBuiltOn().toComputer()
+        runScriptOnChannel(computer.getChannel(), script)
+    }
+
+    def runScriptOnNode(String name, String script) {
+        if (null != jenkins.getNode(name)) {
+            Computer computer = jenkins.getNode(name).toComputer()
+            runScriptOnChannel(computer.getChannel(), script)
+        } else {
+            out.println 'Failed to run script on node $name'
+        }
+    }
+
+
+}

--- a/src/main/groovy/hudson/plugins/groovy/SlaveTask.groovy
+++ b/src/main/groovy/hudson/plugins/groovy/SlaveTask.groovy
@@ -1,0 +1,44 @@
+package hudson.plugins.groovy
+
+import hudson.remoting.DelegatingCallable
+import jenkins.model.Jenkins
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.jenkinsci.remoting.RoleChecker
+
+class SlaveTask implements DelegatingCallable<Void, Exception> {
+
+    private String script
+    private String bindings
+    private def map = [:]
+
+    SlaveTask(String script, String bindings) {
+        this.script = script
+        this.bindings = bindings
+    }
+
+    def putProp = { k, v -> map.put(k, v) }
+
+    def pupPropMap = { m -> map.putAll(m) }
+
+    @Override
+    ClassLoader getClassLoader() {
+        ClassLoader cl = Jenkins.instance.pluginManager.uberClassLoader
+        if (null == cl) {
+            cl = Thread.currentThread().contextClassLoader
+        }
+        return cl
+    }
+
+    @Override
+    Void call() throws Exception {
+        def config = new CompilerConfiguration()
+        def binding = new Binding(Utils.parseProperties(bindings))
+        map.each { k, v -> binding.setProperty(k, v)}
+        def shell = new GroovyShell(getClassLoader(), binding, config)
+        shell.evaluate(script) as Void
+    }
+
+    @Override
+    void checkRoles(RoleChecker checker) throws SecurityException {
+    }
+}

--- a/src/main/java/hudson/plugins/groovy/AbstractGroovy.java
+++ b/src/main/java/hudson/plugins/groovy/AbstractGroovy.java
@@ -4,19 +4,11 @@ import hudson.DescriptorExtensionList;
 import hudson.model.Descriptor;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.Nonnull;
-
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Shared functionality for Groovy builders
@@ -87,16 +79,5 @@ public abstract class AbstractGroovy extends Builder {
     }
 
 
-    public static @Nonnull Properties parseProperties(final String properties) throws IOException {
-        Properties props = new Properties();
 
-        if (properties != null) {
-            try {
-                props.load(new StringReader(properties));
-            } catch (NoSuchMethodError err) {
-                props.load(new ByteArrayInputStream(properties.getBytes()));
-            }
-        }
-        return props;
-    }
 }

--- a/src/main/java/hudson/plugins/groovy/Groovy.java
+++ b/src/main/java/hudson/plugins/groovy/Groovy.java
@@ -6,12 +6,18 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
 import hudson.model.Computer;
 import hudson.model.ParametersAction;
 import hudson.util.VariableResolver;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -20,14 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.StringTokenizer;
-
-import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
-
-import org.apache.commons.exec.CommandLine;
-import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * A Builder for Groovy scripts.
@@ -96,7 +94,7 @@ public class Groovy extends AbstractGroovy {
                 if(this.javaOpts != null) //backward compatibility
                     javaOpts.append(' ').append(this.javaOpts);
                 envVars.put("JAVA_OPTS", javaOpts.toString());
-            
+
                 envVars.put("$PATH_SEPARATOR",":::"); //TODO why??
 
                 result = launcher.launch().cmds(cmd.toArray(new String[] {})).envs(envVars).stdout(listener).pwd(ws).join();
@@ -275,10 +273,10 @@ public class Groovy extends AbstractGroovy {
             }
             list.add(sb.toString());
         }
-        
+
         //Add java properties
         if(StringUtils.isNotBlank(properties)) {
-            for (Entry<Object, Object> entry : parseProperties(properties).entrySet()) {
+            for (Entry<Object, Object> entry : Utils.parseProperties(properties).entrySet()) {
                 list.add("-D" + entry.getKey() + "=" + entry.getValue());
             }
         }

--- a/src/main/java/hudson/plugins/groovy/SystemGroovy.java
+++ b/src/main/java/hudson/plugins/groovy/SystemGroovy.java
@@ -1,36 +1,29 @@
 package hudson.plugins.groovy;
 
+import com.thoughtworks.xstream.XStream;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.Hudson;
+import hudson.model.BuildListener;
 import hudson.util.Secret;
 import hudson.util.VariableResolver;
 import hudson.util.XStream2;
-
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
-
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
 import org.acegisecurity.Authentication;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import com.thoughtworks.xstream.XStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A Builder which executes system Groovy script in Jenkins JVM (similar to JENKINS_URL/script).
@@ -69,7 +62,7 @@ public class SystemGroovy extends AbstractGroovy {
             env.overrideAll(build.getBuildVariables());
             VariableResolver<String> vr = new VariableResolver.ByMap<String>(env);
             if(classpath.contains("\n")) {
-                compilerConfig.setClasspathList(parseClassPath(classpath, vr));
+                compilerConfig.setClasspathList(Utils.parseClassPath(classpath, vr));
             } else {
                 compilerConfig.setClasspath(Util.replaceMacro(classpath,vr));
             }
@@ -84,7 +77,7 @@ public class SystemGroovy extends AbstractGroovy {
 
         // Use HashMap as a backend for Binding as Hashtable does not accept nulls
         Map<Object, Object> binding = new HashMap<Object, Object>();
-        binding.putAll(parseProperties(bindings));
+        binding.putAll(Utils.parseProperties(bindings));
         GroovyShell shell = new GroovyShell(cl, new Binding(binding), compilerConfig);
 
         shell.setVariable("build", build);
@@ -112,15 +105,6 @@ public class SystemGroovy extends AbstractGroovy {
 
         // No output. Suppose success.
         return true;
-    }
-
-    private List<String> parseClassPath(String classPath, VariableResolver<String> vr) {
-        List<String> cp = new ArrayList<String>();
-        StringTokenizer tokens = new StringTokenizer(classPath);
-        while(tokens.hasMoreTokens()) {
-            cp.add(Util.replaceMacro(tokens.nextToken(),vr));
-        }
-        return cp;
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
+++ b/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
@@ -50,7 +50,7 @@ public class SystemScriptRunner<T> {
                 EnvVars env = build.getEnvironment(listener);
                 env.overrideAll(build.getBuildVariables());
                 VariableResolver<String> vr = new VariableResolver.ByMap<>(env);
-                configuration.setClasspathList(Utils.parseClassPath(classpath, vr);
+                configuration.setClasspathList(Utils.parseClassPath(classpath, vr));
             } catch (Exception e) {
                 throw new GroovyScriptExecutionException("Failed to set classpath to groovy configuration",
                                                          e.getCause());

--- a/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
+++ b/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
@@ -39,10 +39,11 @@ public class SystemScriptRunner<T> {
 
     private void init(final String bindings) throws GroovyScriptExecutionException {
         configuration = new CompilerConfiguration();
-        configuration.setScriptBaseClass("hudson.plugins.groovy.AbstractScript");
         ImportCustomizer icz = new ImportCustomizer();
         icz.addStarImports("jenkins", "hudson", "jenkins.model", "hudson.model", "hudson.util", "hudson.remoting");
+        icz.addImports("hudson.plugins.groovy.AbstractScript", "hudson.plugins.groovy.SlaveTask");
         configuration.addCompilationCustomizers(icz);
+        configuration.setScriptBaseClass("hudson.plugins.groovy.AbstractScript");
 
         try {
             binding = new Binding(Utils.parseProperties(bindings));

--- a/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
+++ b/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
@@ -1,0 +1,90 @@
+package hudson.plugins.groovy;
+
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.plugins.groovy.exceptions.GroovyScriptExecutionException;
+import jenkins.model.Jenkins;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.customizers.ImportCustomizer;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+
+/**
+ * A runner which executes system Groovy script in Jenkins JVM. Can be used in internal logic of other Jenkins plugins.
+ * @param <T>
+ *
+ * @author sshelomentsev
+ */
+public class SystemScriptRunner<T> {
+
+    private ScriptSource scriptSource;
+    CompilerConfiguration configuration;
+    Binding binding;
+    ClassLoader cl;
+    AbstractBuild<?, ?> build;
+    BuildListener listener;
+
+    public SystemScriptRunner(ScriptSource scriptSource, final AbstractBuild<?, ?> build, final BuildListener listener,
+                              final String bindings) throws GroovyScriptExecutionException {
+        this.scriptSource = scriptSource;
+        this.build = build;
+        this.listener = listener;
+        init(bindings);
+    }
+
+    private void init(final String bindings) throws GroovyScriptExecutionException {
+        configuration = new CompilerConfiguration();
+        configuration.setScriptBaseClass("hudson.plugins.groovy.AbstractScript");
+        ImportCustomizer icz = new ImportCustomizer();
+        icz.addStarImports("jenkins", "hudson", "jenkins.model", "hudson.model", "hudson.util", "hudson.remoting");
+        configuration.addCompilationCustomizers(icz);
+
+        try {
+            binding = new Binding(Utils.parseProperties(bindings));
+            binding.setVariable("jenkins", Jenkins.getInstance());
+        } catch (IOException e) {
+            throw new GroovyScriptExecutionException("Failed to bind properties to groovy shell");
+        }
+        cl = Jenkins.getInstance().pluginManager.uberClassLoader;
+        if (null == cl) {
+            cl = Thread.currentThread().getContextClassLoader();
+        }
+    }
+
+    public void addEnvVars() {
+        try {
+            EnvVars envVars = build.getEnvironment(listener);
+            envVars.overrideAll(build.getBuildVariables());
+            for (Map.Entry<String, String> entry : envVars.entrySet()) {
+                binding.setProperty(entry.getKey(), entry.getValue());
+            }
+            binding.setVariable("build", build);
+            binding.setVariable("listener", listener);
+            binding.setVariable("out", listener.getLogger());
+        } catch (Exception e) {
+            listener.getLogger().println("Failed to bind environment variables to groovy shell");
+            listener.getLogger().println(e.getMessage());
+        }
+    }
+
+    public void bindVariable(String key, Object value) {
+        binding.setVariable(key, value);
+    }
+
+    public void bindProperty(String key, Object value) {
+        binding.setProperty(key, value);
+    }
+
+    public T evaluate() throws IOException, InterruptedException {
+        GroovyShell shell = new GroovyShell(cl, binding, configuration);
+        Object ret = shell.evaluate(new InputStreamReader(scriptSource.getScriptStream(build.getWorkspace(), build,
+                                                                                       listener)));
+        return (T) ret;
+    }
+
+}

--- a/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
+++ b/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
@@ -61,17 +61,6 @@ public class SystemScriptRunner<T> {
         try {
             binding = new Binding(Utils.parseProperties(bindings));
             binding.setVariable("jenkins", Jenkins.getInstance());
-        } catch (IOException e) {
-            throw new GroovyScriptExecutionException("Failed to bind properties to groovy configuration", e.getCause());
-        }
-        cl = Jenkins.getInstance().pluginManager.uberClassLoader;
-        if (null == cl) {
-            cl = Thread.currentThread().getContextClassLoader();
-        }
-    }
-
-    public void addEnvVars() {
-        try {
             EnvVars envVars = build.getEnvironment(listener);
             envVars.overrideAll(build.getBuildVariables());
             for (Map.Entry<String, String> entry : envVars.entrySet()) {
@@ -81,8 +70,11 @@ public class SystemScriptRunner<T> {
             binding.setVariable("listener", listener);
             binding.setVariable("out", listener.getLogger());
         } catch (Exception e) {
-            listener.getLogger().println("Failed to bind environment variables to groovy shell");
-            listener.getLogger().println(e.getMessage());
+            throw new GroovyScriptExecutionException("Failed to bind properties to groovy configuration", e.getCause());
+        }
+        cl = Jenkins.getInstance().pluginManager.uberClassLoader;
+        if (null == cl) {
+            cl = Thread.currentThread().getContextClassLoader();
         }
     }
 

--- a/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
+++ b/src/main/java/hudson/plugins/groovy/SystemScriptRunner.java
@@ -49,7 +49,7 @@ public class SystemScriptRunner<T> {
             try {
                 EnvVars env = build.getEnvironment(listener);
                 env.overrideAll(build.getBuildVariables());
-                VariableResolver<String> vr = new VariableResolver.ByMap<>(env);
+                VariableResolver<String> vr = new VariableResolver.ByMap<String>(env);
                 configuration.setClasspathList(Utils.parseClassPath(classpath, vr));
             } catch (Exception e) {
                 throw new GroovyScriptExecutionException("Failed to set classpath to groovy configuration",

--- a/src/main/java/hudson/plugins/groovy/Utils.java
+++ b/src/main/java/hudson/plugins/groovy/Utils.java
@@ -1,0 +1,41 @@
+package hudson.plugins.groovy;
+
+import hudson.Util;
+import hudson.util.VariableResolver;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.StringTokenizer;
+
+public final class Utils {
+
+    private Utils() { }
+
+    public static @Nonnull
+    Properties parseProperties(final String properties) throws IOException {
+        Properties props = new Properties();
+
+        if (properties != null) {
+            try {
+                props.load(new StringReader(properties));
+            } catch (NoSuchMethodError err) {
+                props.load(new ByteArrayInputStream(properties.getBytes()));
+            }
+        }
+        return props;
+    }
+
+    public static List<String> parseClassPath(String classPath, VariableResolver<String> vr) {
+        List<String> cp = new ArrayList<String>();
+        StringTokenizer tokens = new StringTokenizer(classPath);
+        while(tokens.hasMoreTokens()) {
+            cp.add(Util.replaceMacro(tokens.nextToken(), vr));
+        }
+        return cp;
+    }
+}

--- a/src/main/java/hudson/plugins/groovy/exceptions/GroovyScriptExecutionException.java
+++ b/src/main/java/hudson/plugins/groovy/exceptions/GroovyScriptExecutionException.java
@@ -1,0 +1,21 @@
+package hudson.plugins.groovy.exceptions;
+
+/**
+ * Thrown to indicate that there are some problems while working with script runner.
+ *
+ * @author sshelomentsev
+ */
+public class GroovyScriptExecutionException extends Exception {
+
+    public GroovyScriptExecutionException(String message) {
+        super(message);
+    }
+
+    public GroovyScriptExecutionException(Throwable cause) {
+        super(cause);
+    }
+
+    public GroovyScriptExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Hi everyone,

In several our plugins we want to run groovy script as a part of some performing logic (in build or post-build steps). So, I think it make sense to implement basic functionality that can be used by other plugins.
Example of use: we have a plugin that provides build step with groovy script. If groovy script evaluation return true, the step trigger other job. It's not simple condition, so we want to send requests to some REST API or have access to hudson.model. 

It's a groovy compiler configuration with Jenkins classloader, variable bindings and additional classpath.
Also, it's possible to run a part of groovy script on a slave node by DelegatingCallable interface.

In our plugins we use code like:
```
private boolean isStart(final AbstractBuild<?, ?> build, final BuildListener listener) throws
            GroovyScriptExecutionException, IOException, InterruptedException {

        ScriptSource source = new StringScriptSource(script);

        SystemScriptRunner<Boolean> runner = new SystemScriptRunner<>(source, build, listener, bindings);

        return runner.evaluate();
    }
```

Hope, my request is clear.