### PR TITLE
Adding a symbol to GroovyInstallation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>script-security</artifactId>
             <version>1.24</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.7</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/hudson/plugins/groovy/GroovyInstallation.java
+++ b/src/main/java/hudson/plugins/groovy/GroovyInstallation.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
+import org.jenkinsci.Symbol;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -68,6 +69,7 @@ public class GroovyInstallation extends ToolInstallation implements EnvironmentS
         return new GroovyInstallation(getName(), translateFor(node, log), getProperties().toList());
     }
 
+    @Symbol("groovy")
     @Extension
     public static class DescriptorImpl extends ToolDescriptor<GroovyInstallation> {
 


### PR DESCRIPTION
I thought @abayer did a bunch of these in batch in some point, but perhaps I am thinking of something else.

Supposedly would have avoided the need for https://github.com/jenkins-infra/crawler/pull/62. Not straightforward to demonstrate in a functional test since the 1.580.x baseline in this plugin precludes testing against contemporary Pipeline plugins (typically 1.642.x, and 2.7.x for Declarative).

@reviewbybees