### PR TITLE
Define `GROOVY_HOME`

### DIFF
--- a/src/main/java/hudson/plugins/groovy/WithGroovyStep.java
+++ b/src/main/java/hudson/plugins/groovy/WithGroovyStep.java
@@ -112,6 +112,7 @@ public class WithGroovyStep extends Step {
                     installation = installation.forEnvironment(getContext().get(EnvVars.class));
                     String home = installation.getHome();
                     env.put("PATH+GROOVY", tmp.child(home).child("bin").getRemote());
+                    env.put("GROOVY_HOME", tmp.child(home).getRemote());
                 } else {
                     FilePath bin = tmp.child("bin");
                     FilePath groovySh = bin.child("groovy");

--- a/src/test/java/hudson/plugins/groovy/WithGroovyStepTest.java
+++ b/src/test/java/hudson/plugins/groovy/WithGroovyStepTest.java
@@ -81,7 +81,7 @@ public class WithGroovyStepTest {
         r.jenkins.getDescriptorByType(GroovyInstallation.DescriptorImpl.class).setInstallations(new GroovyInstallation("2.4.x", home.child("groovy-2.4.13").getRemote(), null));
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
         r.jenkins.getWorkspaceFor(p).child("x.groovy").write("println(/running $GroovySystem.version/)", null);
-        p.setDefinition(new CpsFlowDefinition("node {withGroovy(tool: '2.4.x') {if (isUnix()) {sh 'env | fgrep PATH; groovy x.groovy'} else {bat 'groovy x.groovy'}}}", true));
+        p.setDefinition(new CpsFlowDefinition("node {withGroovy(tool: '2.4.x') {if (isUnix()) {sh 'env | egrep \"PATH|GROOVY\"; groovy x.groovy'} else {bat 'groovy x.groovy'}}}", true));
         r.assertLogContains("running 2.4.13", r.buildAndAssertSuccess(p));
     }
 


### PR DESCRIPTION
Without this I get

```
Error: Could not find or load main class org.codehaus.groovy.tools.GroovyStarter
```

which seems to be due to

```console
$ env|fgrep -i groovy
GROOVY_HOME=/home/jglick/.sdkman/candidates/groovy/current
PATH=…:/home/jglick/.sdkman/candidates/groovy/current/bin:…
```
